### PR TITLE
Removed redirect back to referrer from parts delete

### DIFF
--- a/parts_server.rb
+++ b/parts_server.rb
@@ -289,7 +289,7 @@ module CheesyParts
       halt(400, "Invalid part.") if @part.nil?
       halt(400, "Can't delete assembly with existing children.") unless @part.child_parts.empty?
       @part.delete
-      redirect params[:referrer] || "/projects/#{project_id}"
+      redirect "/projects/#{project_id}"
     end
 
     get "/new_user" do


### PR DESCRIPTION
Just a quick fix

When deleting a part, there's an issue with the redirects. It'll redirect you back to the part's page that's now deleted (I'm assuming params[:referrer] refers to the previous part's page). Now it only redirects back to the dashboard page.
