### PR TITLE
Fix error upon initial project creation

### DIFF
--- a/parts_server.rb
+++ b/parts_server.rb
@@ -115,7 +115,7 @@ module CheesyParts
       halt(400, "Missing project name.") if params[:name].nil?
       halt(400, "Missing part number prefix.") if params[:part_number_prefix].nil?
 
-      project = Project.create(:name => params[:name], :part_number_prefix => params[:part_number_prefix])
+      project = Project.create(:name => params[:name], :part_number_prefix => params[:part_number_prefix], :hide_dashboards => false)
       redirect "/projects/#{project.id}"
     end
 


### PR DESCRIPTION
New projects could not be created due to a missing default value for `hide_dashboards`.

Server: 
Ubuntu 16.04.3 LTS
Ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
MySQL 5.7.23-0ubuntu0.16.04.1