### PR TITLE
Fix misaligned project list items on Projects tab

### DIFF
--- a/public/css/css.css
+++ b/public/css/css.css
@@ -86,3 +86,7 @@ label {
 .table th a {
   color: black;
 }
+
+.project-li {
+  display: inline-block;
+}

--- a/views/projects.erb
+++ b/views/projects.erb
@@ -15,7 +15,7 @@
   </div>
   <div class="well">
   <% Project.each do |project| %>
-    <li><h4><a href="/projects/<%= project.id %>"><%= project.name %></a></h4></li>
+    <li><h4 class="project-li"><a href="/projects/<%= project.id %>"><%= project.name %></a></h4></li>
   <% end %>
   </div>
 </div>


### PR DESCRIPTION
Without additional styling, the project list items are not aligned with the bullet points from the <li> styling.

Before:

![image](https://user-images.githubusercontent.com/4739008/45701935-7def4780-bb3e-11e8-9053-6b8e430aef23.png)

After:

![image](https://user-images.githubusercontent.com/4739008/45701981-9e1f0680-bb3e-11e8-9989-d5397d0802de.png)

This could have been accomplished via directly adding the CSS to the line, but I prefer using classes where possible.