### PR TITLE
Fix misaligned list items in projects/dashboards/orders tabs

### DIFF
--- a/public/css/css.css
+++ b/public/css/css.css
@@ -86,3 +86,7 @@ label {
 .table th a {
   color: black;
 }
+
+li > h4 {
+  display: inline-block;
+}


### PR DESCRIPTION
This restyles the Projects, Dashboards, and Orders pages so that the `<h4>` element is aligned with the bullet point from the `<li>`.

Same concept as #18, but this is a more general solution.